### PR TITLE
EdnaChat: renderiza HTML (tabelas) e adiciona historico de conversas

### DIFF
--- a/src/components/EdnaChat/index.tsx
+++ b/src/components/EdnaChat/index.tsx
@@ -1,16 +1,25 @@
 import { useState, useRef, useEffect } from 'react';
 import Link from 'next/link';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCommentDots, faXmark, faPaperPlane, faMicrophone, faImage } from '@fortawesome/free-solid-svg-icons';
+import { faCommentDots, faXmark, faPaperPlane, faMicrophone, faImage, faPlus, faClockRotateLeft } from '@fortawesome/free-solid-svg-icons';
 import { api } from '@/services/apiClient';
 import { AxiosError, AxiosResponse } from 'axios';
 import { toast } from 'react-toastify';
 import styles from './styles.module.scss';
 
-type Mensagem = { autor: 'usuario' | 'edna'; texto: string; imagens?: string[] };
+// html só vem preenchido em mensagens da Edna: é o Markdown que ela escreveu já
+// renderizado pelo backend (tabelas de relatório viram <table>). Quando existe,
+// renderizamos ele; senão caímos no texto puro.
+type Mensagem = { autor: 'usuario' | 'edna'; texto: string; imagens?: string[]; html?: string };
 type ImagemSelecionada = { preview: string };
+type ConversaResumo = { id: string; titulo: string; createdAt: string; updatedAt: string };
 
 const MAX_IMAGENS = 3;
+
+const SAUDACAO: Mensagem = {
+    autor: 'edna',
+    texto: 'Oi! Sou a Edina. Pode pedir um relatório ou uma alteração, por exemplo: "vendas dos últimos 15 dias".',
+};
 
 // Detecta caminhos "/relatorio/algo" na resposta da Edna e transforma em
 // botão clicável — a IA já foi instruída a sempre incluir a URL quando
@@ -28,29 +37,49 @@ function renderMensagemComLinks(texto: string) {
     );
 }
 
+// No modo HTML o path do relatório fica como texto dentro do HTML, então não dá
+// pra trocar por um <Link> inline — adicionamos o botão logo abaixo da mensagem.
+function renderBotaoRelatorio(texto: string) {
+    const match = texto.match(/\/relatorio\/[a-zA-Z0-9]+/);
+    if (!match) return null;
+    return (
+        <Link href={match[0]} className={styles.linkRelatorio}>
+            📊 Abrir relatório completo
+        </Link>
+    );
+}
+
+function formatarData(iso: string) {
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return '';
+    return d.toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit' });
+}
+
 interface EdnaChatProps {
     empresaId: number;
 }
 
 export default function EdnaChat({ empresaId }: EdnaChatProps) {
     const [aberto, setAberto] = useState(false);
-    const [mensagens, setMensagens] = useState<Mensagem[]>([
-        { autor: 'edna', texto: 'Oi! Sou a Edina. Pode pedir um relatório ou uma alteração, por exemplo: "vendas dos últimos 15 dias".' },
-    ]);
+    const [mensagens, setMensagens] = useState<Mensagem[]>([SAUDACAO]);
     const [input, setInput] = useState('');
     const [imagens, setImagens] = useState<ImagemSelecionada[]>([]);
     const [enviando, setEnviando] = useState(false);
     const [gravando, setGravando] = useState(false);
     const [transcrevendo, setTranscrevendo] = useState(false);
     const [conversationId, setConversationId] = useState<string | undefined>();
+    const [mostrandoHistorico, setMostrandoHistorico] = useState(false);
+    const [conversas, setConversas] = useState<ConversaResumo[]>([]);
+    const [carregandoHistorico, setCarregandoHistorico] = useState(false);
+    const [carregandoConversa, setCarregandoConversa] = useState(false);
     const fimDaListaRef = useRef<HTMLDivElement>(null);
     const mediaRecorderRef = useRef<MediaRecorder | null>(null);
     const chunksRef = useRef<Blob[]>([]);
     const fileInputRef = useRef<HTMLInputElement>(null);
 
     useEffect(() => {
-        if (aberto) fimDaListaRef.current?.scrollIntoView({ behavior: 'smooth' });
-    }, [mensagens, aberto, gravando, transcrevendo]);
+        if (aberto && !mostrandoHistorico) fimDaListaRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }, [mensagens, aberto, gravando, transcrevendo, mostrandoHistorico]);
 
     // Redimensiona no navegador antes de mandar — fotos de celular vêm
     // grandes, isso evita estourar o limite de tamanho da requisição e
@@ -96,6 +125,43 @@ export default function EdnaChat({ empresaId }: EdnaChatProps) {
         setImagens((atual) => atual.filter((_, i) => i !== index));
     }
 
+    // ── Histórico de conversas (persistido por empresa+usuário no backend) ──
+    async function abrirHistorico() {
+        setMostrandoHistorico(true);
+        setCarregandoHistorico(true);
+        await api.get('/edna/conversas', { params: { empresaId } })
+            .then(({ data }: AxiosResponse) => setConversas(data ?? []))
+            .catch(() => toast.error('Não consegui carregar suas conversas anteriores.'))
+            .finally(() => setCarregandoHistorico(false));
+    }
+
+    // Carrega os turnos salvos e reassume o conversationId — a partir daí o
+    // usuário continua conversando de onde parou.
+    async function abrirConversa(id: string) {
+        setCarregandoConversa(true);
+        await api.get(`/edna/conversas/${id}/mensagens`, { params: { empresaId } })
+            .then(({ data }: AxiosResponse) => {
+                const msgs: Mensagem[] = (data ?? []).map((m: any) => ({
+                    autor: m.role === 'user' ? 'usuario' : 'edna',
+                    texto: m.conteudo,
+                    html: m.role === 'user' ? undefined : (m.html ?? undefined),
+                }));
+                setMensagens(msgs.length ? msgs : [SAUDACAO]);
+                setConversationId(id);
+                setMostrandoHistorico(false);
+            })
+            .catch(() => toast.error('Não consegui abrir essa conversa.'))
+            .finally(() => setCarregandoConversa(false));
+    }
+
+    function novaConversa() {
+        setMensagens([SAUDACAO]);
+        setConversationId(undefined);
+        setInput('');
+        setImagens([]);
+        setMostrandoHistorico(false);
+    }
+
     // Envia um texto já pronto (digitado ou transcrito), com ou sem imagens
     // anexadas — função única reaproveitada pelos dois fluxos de entrada.
     async function enviarTexto(texto: string, imagensParaEnviar: string[] = []) {
@@ -111,7 +177,7 @@ export default function EdnaChat({ empresaId }: EdnaChatProps) {
         )
             .then(({ data }: AxiosResponse) => {
                 setConversationId(data.conversationId);
-                setMensagens((atual) => [...atual, { autor: 'edna', texto: data.reply }]);
+                setMensagens((atual) => [...atual, { autor: 'edna', texto: data.reply, html: data.replyHtml }]);
             })
             .catch((err: AxiosError) => {
                 if (err.response?.status === 429) {
@@ -198,28 +264,73 @@ export default function EdnaChat({ empresaId }: EdnaChatProps) {
                 <div className={styles.painel}>
                     <div className={styles.cabecalho}>
                         <span>Edina</span>
-                        <a onClick={() => setAberto(false)}><FontAwesomeIcon icon={faXmark} /></a>
+                        <div className={styles.acoesCabecalho}>
+                            <a title="Nova conversa" onClick={novaConversa}><FontAwesomeIcon icon={faPlus} /></a>
+                            <a
+                                title="Conversas anteriores"
+                                className={mostrandoHistorico ? styles.acaoAtiva : undefined}
+                                onClick={() => (mostrandoHistorico ? setMostrandoHistorico(false) : abrirHistorico())}
+                            >
+                                <FontAwesomeIcon icon={faClockRotateLeft} />
+                            </a>
+                            <a title="Fechar" onClick={() => setAberto(false)}><FontAwesomeIcon icon={faXmark} /></a>
+                        </div>
                     </div>
 
-                    <div className={styles.mensagens}>
-                        {mensagens.map((m, i) => (
-                            <div key={i} className={m.autor === 'usuario' ? styles.bolhaUsuario : styles.bolhaEdna}>
-                                {m.imagens && m.imagens.length > 0 && (
-                                    <div className={styles.miniaturasEnviadas}>
-                                        {m.imagens.map((src, j) => (
-                                            /* eslint-disable-next-line @next/next/no-img-element */
-                                            <img key={j} src={src} alt="Imagem enviada" className={styles.miniatura} />
-                                        ))}
-                                    </div>
-                                )}
-                                {m.texto && (m.autor === 'edna' ? renderMensagemComLinks(m.texto) : m.texto)}
-                            </div>
-                        ))}
-                        {enviando && !transcrevendo && <div className={styles.digitando}>digitando…</div>}
-                        <div ref={fimDaListaRef} />
-                    </div>
+                    {mostrandoHistorico ? (
+                        <div className={styles.listaConversas}>
+                            {carregandoHistorico ? (
+                                <div className={styles.infoHistorico}>Carregando conversas…</div>
+                            ) : conversas.length === 0 ? (
+                                <div className={styles.infoHistorico}>Você ainda não tem conversas salvas.</div>
+                            ) : (
+                                conversas.map((c) => (
+                                    <a key={c.id} className={styles.itemConversa} onClick={() => abrirConversa(c.id)}>
+                                        <span className={styles.tituloConversa}>{c.titulo}</span>
+                                        <span className={styles.dataConversa}>{formatarData(c.updatedAt)}</span>
+                                    </a>
+                                ))
+                            )}
+                            {carregandoConversa && <div className={styles.infoHistorico}>Abrindo conversa…</div>}
+                        </div>
+                    ) : (
+                        <div className={styles.mensagens}>
+                            {mensagens.map((m, i) => (
+                                <div key={i} className={m.autor === 'usuario' ? styles.bolhaUsuario : styles.bolhaEdna}>
+                                    {m.imagens && m.imagens.length > 0 && (
+                                        <div className={styles.miniaturasEnviadas}>
+                                            {m.imagens.map((src, j) => (
+                                                /* eslint-disable-next-line @next/next/no-img-element */
+                                                <img key={j} src={src} alt="Imagem enviada" className={styles.miniatura} />
+                                            ))}
+                                        </div>
+                                    )}
+                                    {m.autor === 'edna' ? (
+                                        m.html ? (
+                                            <>
+                                                {/* Seguro: o backend renderiza o Markdown com Markdig +
+                                                    DisableHtml(), então HTML/script vindo de dados já
+                                                    chega escapado como texto. */}
+                                                <div
+                                                    className={styles.htmlContent}
+                                                    dangerouslySetInnerHTML={{ __html: m.html }}
+                                                />
+                                                {renderBotaoRelatorio(m.texto)}
+                                            </>
+                                        ) : (
+                                            m.texto && renderMensagemComLinks(m.texto)
+                                        )
+                                    ) : (
+                                        m.texto
+                                    )}
+                                </div>
+                            ))}
+                            {enviando && !transcrevendo && <div className={styles.digitando}>digitando…</div>}
+                            <div ref={fimDaListaRef} />
+                        </div>
+                    )}
 
-                    {gravando ? (
+                    {!mostrandoHistorico && (gravando ? (
                         <div className={styles.gravacaoCentral}>
                             <a className={styles.botaoGravandoGrande} onClick={alternarGravacao} title="Toque para parar e enviar">
                                 <FontAwesomeIcon icon={faMicrophone} size="lg" />
@@ -277,7 +388,7 @@ export default function EdnaChat({ empresaId }: EdnaChatProps) {
                                 </button>
                             </form>
                         </>
-                    )}
+                    ))}
                 </div>
             )}
 

--- a/src/components/EdnaChat/styles.module.scss
+++ b/src/components/EdnaChat/styles.module.scss
@@ -50,6 +50,25 @@
     }
 }
 
+.acoesCabecalho {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+
+    a {
+        opacity: 0.85;
+
+        &:hover {
+            opacity: 1;
+        }
+    }
+}
+
+.acaoAtiva {
+    opacity: 1 !important;
+    text-shadow: 0 0 8px rgba(255, 255, 255, 0.8);
+}
+
 .mensagens {
     flex: 1;
     overflow-y: auto;
@@ -57,6 +76,50 @@
     display: flex;
     flex-direction: column;
     gap: 8px;
+}
+
+// ── Lista de conversas anteriores ─────────────────────────────────────
+.listaConversas {
+    flex: 1;
+    overflow-y: auto;
+    padding: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.itemConversa {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 10px 12px;
+    border-radius: 8px;
+    cursor: pointer;
+    background: #f7f7f7;
+
+    &:hover {
+        background: #ececec;
+    }
+}
+
+.tituloConversa {
+    font-size: 0.9rem;
+    color: #111;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.dataConversa {
+    font-size: 0.72rem;
+    color: #999;
+}
+
+.infoHistorico {
+    text-align: center;
+    color: #888;
+    font-size: 0.85rem;
+    padding: 16px;
 }
 
 .bolhaUsuario {
@@ -83,6 +146,65 @@
     align-self: flex-start;
     color: #888;
     font-size: 0.85rem;
+}
+
+// ── Conteúdo HTML renderizado do Markdown (tabelas de relatório, etc) ──
+// A bolha da Edna usa white-space: pre-wrap; aqui dentro voltamos ao normal
+// pra o HTML fluir certo (tabelas, parágrafos, listas).
+.htmlContent {
+    white-space: normal;
+    font-size: 0.9rem;
+    line-height: 1.4;
+
+    p {
+        margin: 0 0 6px;
+
+        &:last-child {
+            margin-bottom: 0;
+        }
+    }
+
+    ul,
+    ol {
+        margin: 4px 0;
+        padding-left: 18px;
+    }
+
+    a {
+        color: var(--main);
+        text-decoration: underline;
+        word-break: break-word;
+    }
+
+    table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 6px 0;
+        font-size: 0.82rem;
+    }
+
+    th,
+    td {
+        border: 1px solid #d9d9d9;
+        padding: 4px 8px;
+        text-align: left;
+    }
+
+    th {
+        background: #e9e9e9;
+        font-weight: 600;
+    }
+
+    tr:nth-child(even) td {
+        background: #fafafa;
+    }
+
+    code {
+        background: #e6e6e6;
+        padding: 1px 4px;
+        border-radius: 4px;
+        font-size: 0.85em;
+    }
 }
 
 .rodape {


### PR DESCRIPTION
## O quê

Integra o `EdnaChat` com as melhorias do backend da Edna (WEBApi PRs #2/#3). Dois arquivos: `index.tsx` e `styles.module.scss`.

## 1. Exibição em HTML (tabelas de verdade)

As mensagens da Edna agora renderizam o **`replyHtml`** devolvido pela API, então relatórios aparecem como **tabela** em vez de texto cru. O container `.htmlContent` estiliza `table`/`th`/`td`, listas, código e links.

**Segurança:** o backend renderiza o Markdown com Markdig + `.DisableHtml()`, então HTML/script vindo de dados (ex: descrição de produto) já chega **escapado como texto**. Por isso o `dangerouslySetInnerHTML` aqui é seguro — está comentado no código.

Mensagens sem `html` (ex: erros locais de rede/429) continuam caindo no texto puro de antes.

## 2. Histórico de conversas

- Botão de **relógio** no cabeçalho → lista as conversas anteriores (`GET /edna/conversas`)
- Clicar numa conversa → carrega os turnos (`GET /edna/conversas/{id}/mensagens`) com o HTML já renderizado e **reassume o `conversationId`**, então o usuário continua de onde parou
- Botão **+** → começa uma conversa nova

## 3. Botão de relatório preservado

No modo HTML o path `/relatorio/x` fica como texto dentro do HTML, então não dá pra trocar por um `<Link>` inline. O botão "Abrir relatório completo" passou a ser renderizado separado, logo abaixo da mensagem — o comportamento pro usuário continua o mesmo.

## Notas para o revisor

- `tsc --noEmit` limpo.
- **Depende do backend** já estar no ar com `replyHtml` e os endpoints de histórico (WEBApi PRs #2/#3 já mergeados), e com as tabelas `edna_chat` criadas. Se o backend for antigo, `data.replyHtml` vem `undefined` e o componente cai no texto puro — degrada sem quebrar.
- Nenhuma dependência nova.
- Não mexi em nada fora do componente `EdnaChat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
